### PR TITLE
Add chemical product management

### DIFF
--- a/backend/src/main/java/com/chemreg/chemreg/chemical/ChemicalIntegrationStubs.java
+++ b/backend/src/main/java/com/chemreg/chemreg/chemical/ChemicalIntegrationStubs.java
@@ -1,0 +1,20 @@
+package com.chemreg.chemreg.chemical;
+
+import java.util.UUID;
+
+/**
+ * Temporary integration constants for the chemical module.
+ */
+public final class ChemicalIntegrationStubs {
+
+    private ChemicalIntegrationStubs() {
+    }
+
+    /**
+     * Single-tenant stub until the tenant/auth workstream provides a resolved tenant (e.g. JWT, {@code SecurityContext}).
+     * <p>
+     * The corresponding {@code tenants} row is created idempotently at runtime by {@link StubTenantProvisioner}
+     * before stub-tenant chemical writes. Replace usages with the current tenant from your security layer when that ships.
+     */
+    public static final UUID STUB_TENANT_ID = UUID.fromString("c0000000-0000-4000-8000-000000000001");
+}

--- a/backend/src/main/java/com/chemreg/chemreg/chemical/StubTenantProvisioner.java
+++ b/backend/src/main/java/com/chemreg/chemreg/chemical/StubTenantProvisioner.java
@@ -1,0 +1,33 @@
+package com.chemreg.chemreg.chemical;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Idempotently ensures the dev/stub tenant row exists before chemical product writes that reference
+ * {@link ChemicalIntegrationStubs#STUB_TENANT_ID}.
+ */
+@Component
+public class StubTenantProvisioner {
+
+    private static final String STUB_TENANT_NAME = "ChemReg dev stub tenant";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public StubTenantProvisioner(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void ensureStubTenantExists() {
+        jdbcTemplate.update(
+                """
+                INSERT INTO tenants (id, name, plan, settings_json, created_at, updated_at)
+                VALUES (?, ?, ?, ?::jsonb, now(), now())
+                ON CONFLICT (id) DO NOTHING
+                """,
+                ChemicalIntegrationStubs.STUB_TENANT_ID,
+                STUB_TENANT_NAME,
+                "mvp",
+                "{}");
+    }
+}

--- a/backend/src/main/java/com/chemreg/chemreg/chemical/controller/ChemicalProductController.java
+++ b/backend/src/main/java/com/chemreg/chemreg/chemical/controller/ChemicalProductController.java
@@ -1,0 +1,59 @@
+package com.chemreg.chemreg.chemical.controller;
+
+import com.chemreg.chemreg.chemical.dto.ChemicalProductResponse;
+import com.chemreg.chemreg.chemical.dto.SaveChemicalProductRequest;
+import com.chemreg.chemreg.chemical.service.ChemicalProductService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/chemical-products")
+public class ChemicalProductController {
+
+    private final ChemicalProductService chemicalProductService;
+
+    public ChemicalProductController(ChemicalProductService chemicalProductService) {
+        this.chemicalProductService = chemicalProductService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChemicalProductResponse>> list() {
+        return ResponseEntity.ok(chemicalProductService.listAllForStubTenant());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ChemicalProductResponse> getById(@PathVariable UUID id) {
+        return ResponseEntity.ok(chemicalProductService.getById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<ChemicalProductResponse> create(@Valid @RequestBody SaveChemicalProductRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(chemicalProductService.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ChemicalProductResponse> update(
+            @PathVariable UUID id,
+            @Valid @RequestBody SaveChemicalProductRequest request
+    ) {
+        return ResponseEntity.ok(chemicalProductService.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        chemicalProductService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/chemreg/chemreg/chemical/dto/ChemicalProductResponse.java
+++ b/backend/src/main/java/com/chemreg/chemreg/chemical/dto/ChemicalProductResponse.java
@@ -1,0 +1,112 @@
+package com.chemreg.chemreg.chemical.dto;
+
+import com.chemreg.chemreg.common.enums.ChemicalSignalWord;
+import com.chemreg.chemreg.common.enums.PhysicalState;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public class ChemicalProductResponse {
+
+    private UUID id;
+    /** Present for API clarity; will come from security context once multi-tenant auth is wired. */
+    private UUID tenantId;
+    /** Always null until SDS linking is implemented for this API. */
+    private UUID sdsDocumentId;
+    private String name;
+    private String casNumber;
+    private String ecNumber;
+    private ChemicalSignalWord signalWord;
+    private PhysicalState physicalState;
+    private Boolean restricted;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public UUID getSdsDocumentId() {
+        return sdsDocumentId;
+    }
+
+    public void setSdsDocumentId(UUID sdsDocumentId) {
+        this.sdsDocumentId = sdsDocumentId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCasNumber() {
+        return casNumber;
+    }
+
+    public void setCasNumber(String casNumber) {
+        this.casNumber = casNumber;
+    }
+
+    public String getEcNumber() {
+        return ecNumber;
+    }
+
+    public void setEcNumber(String ecNumber) {
+        this.ecNumber = ecNumber;
+    }
+
+    public ChemicalSignalWord getSignalWord() {
+        return signalWord;
+    }
+
+    public void setSignalWord(ChemicalSignalWord signalWord) {
+        this.signalWord = signalWord;
+    }
+
+    public PhysicalState getPhysicalState() {
+        return physicalState;
+    }
+
+    public void setPhysicalState(PhysicalState physicalState) {
+        this.physicalState = physicalState;
+    }
+
+    public Boolean getRestricted() {
+        return restricted;
+    }
+
+    public void setRestricted(Boolean restricted) {
+        this.restricted = restricted;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/chemreg/chemreg/chemical/dto/SaveChemicalProductRequest.java
+++ b/backend/src/main/java/com/chemreg/chemreg/chemical/dto/SaveChemicalProductRequest.java
@@ -1,0 +1,73 @@
+package com.chemreg.chemreg.chemical.dto;
+
+import com.chemreg.chemreg.common.enums.ChemicalSignalWord;
+import com.chemreg.chemreg.common.enums.PhysicalState;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class SaveChemicalProductRequest {
+
+    @NotBlank
+    @Size(max = 255)
+    private String name;
+
+    @Size(max = 50)
+    private String casNumber;
+
+    @Size(max = 50)
+    private String ecNumber;
+
+    private ChemicalSignalWord signalWord;
+
+    private PhysicalState physicalState;
+
+    private Boolean restricted;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCasNumber() {
+        return casNumber;
+    }
+
+    public void setCasNumber(String casNumber) {
+        this.casNumber = casNumber;
+    }
+
+    public String getEcNumber() {
+        return ecNumber;
+    }
+
+    public void setEcNumber(String ecNumber) {
+        this.ecNumber = ecNumber;
+    }
+
+    public ChemicalSignalWord getSignalWord() {
+        return signalWord;
+    }
+
+    public void setSignalWord(ChemicalSignalWord signalWord) {
+        this.signalWord = signalWord;
+    }
+
+    public PhysicalState getPhysicalState() {
+        return physicalState;
+    }
+
+    public void setPhysicalState(PhysicalState physicalState) {
+        this.physicalState = physicalState;
+    }
+
+    public Boolean getRestricted() {
+        return restricted;
+    }
+
+    public void setRestricted(Boolean restricted) {
+        this.restricted = restricted;
+    }
+}

--- a/backend/src/main/java/com/chemreg/chemreg/chemical/repository/ChemicalProductRepository.java
+++ b/backend/src/main/java/com/chemreg/chemreg/chemical/repository/ChemicalProductRepository.java
@@ -8,5 +8,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface ChemicalProductRepository extends JpaRepository<ChemicalProduct, UUID> {
-List<ChemicalProduct> findByTenantId(UUID tenantId);
+
+    List<ChemicalProduct> findByTenantId(UUID tenantId);
+
+    Optional<ChemicalProduct> findByIdAndTenant_Id(UUID id, UUID tenantId);
 }

--- a/backend/src/main/java/com/chemreg/chemreg/chemical/service/ChemicalProductService.java
+++ b/backend/src/main/java/com/chemreg/chemreg/chemical/service/ChemicalProductService.java
@@ -1,0 +1,116 @@
+package com.chemreg.chemreg.chemical.service;
+
+import com.chemreg.chemreg.chemical.ChemicalIntegrationStubs;
+import com.chemreg.chemreg.chemical.StubTenantProvisioner;
+import com.chemreg.chemreg.chemical.dto.ChemicalProductResponse;
+import com.chemreg.chemreg.chemical.dto.SaveChemicalProductRequest;
+import com.chemreg.chemreg.chemical.entity.ChemicalProduct;
+import com.chemreg.chemreg.chemical.repository.ChemicalProductRepository;
+import com.chemreg.chemreg.common.exception.ResourceNotFoundException;
+import com.chemreg.chemreg.tenant.entity.Tenant;
+import com.chemreg.chemreg.tenant.repository.TenantRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ChemicalProductService {
+
+    private final ChemicalProductRepository chemicalProductRepository;
+    private final TenantRepository tenantRepository;
+    private final StubTenantProvisioner stubTenantProvisioner;
+
+    public ChemicalProductService(
+            ChemicalProductRepository chemicalProductRepository,
+            TenantRepository tenantRepository,
+            StubTenantProvisioner stubTenantProvisioner
+    ) {
+        this.chemicalProductRepository = chemicalProductRepository;
+        this.tenantRepository = tenantRepository;
+        this.stubTenantProvisioner = stubTenantProvisioner;
+    }
+
+    @Transactional
+    public ChemicalProductResponse create(SaveChemicalProductRequest request) {
+        stubTenantProvisioner.ensureStubTenantExists();
+        Tenant tenant = tenantRepository.findById(ChemicalIntegrationStubs.STUB_TENANT_ID)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Tenant not found: " + ChemicalIntegrationStubs.STUB_TENANT_ID));
+
+        ChemicalProduct product = new ChemicalProduct();
+        product.setTenant(tenant);
+        applyRequestFields(product, request);
+
+        // TODO(team/sds): When SDS linking API exists, set SdsDocument from a validated id for this tenant.
+        // New products intentionally have no SDS association from this endpoint.
+
+        ChemicalProduct saved = chemicalProductRepository.save(product);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public List<ChemicalProductResponse> listAllForStubTenant() {
+        return chemicalProductRepository.findByTenantId(ChemicalIntegrationStubs.STUB_TENANT_ID).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public ChemicalProductResponse getById(UUID id) {
+        ChemicalProduct product = chemicalProductRepository
+                .findByIdAndTenant_Id(id, ChemicalIntegrationStubs.STUB_TENANT_ID)
+                .orElseThrow(() -> new ResourceNotFoundException("Chemical product not found: " + id));
+        return toResponse(product);
+    }
+
+    @Transactional
+    public ChemicalProductResponse update(UUID id, SaveChemicalProductRequest request) {
+        ChemicalProduct product = chemicalProductRepository
+                .findByIdAndTenant_Id(id, ChemicalIntegrationStubs.STUB_TENANT_ID)
+                .orElseThrow(() -> new ResourceNotFoundException("Chemical product not found: " + id));
+
+        applyRequestFields(product, request);
+        // Do not modify sdsDocument here; SDS workstream will own linking.
+
+        return toResponse(chemicalProductRepository.save(product));
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        ChemicalProduct product = chemicalProductRepository
+                .findByIdAndTenant_Id(id, ChemicalIntegrationStubs.STUB_TENANT_ID)
+                .orElseThrow(() -> new ResourceNotFoundException("Chemical product not found: " + id));
+        chemicalProductRepository.delete(product);
+    }
+
+    private void applyRequestFields(ChemicalProduct product, SaveChemicalProductRequest request) {
+        product.setName(request.getName().trim());
+        product.setCasNumber(request.getCasNumber());
+        product.setEcNumber(request.getEcNumber());
+        product.setSignalWord(request.getSignalWord());
+        product.setPhysicalState(request.getPhysicalState());
+        product.setRestricted(request.getRestricted() != null ? request.getRestricted() : Boolean.FALSE);
+    }
+
+    private ChemicalProductResponse toResponse(ChemicalProduct product) {
+        ChemicalProductResponse response = new ChemicalProductResponse();
+        response.setId(product.getId());
+        response.setTenantId(product.getTenant().getId());
+        if (product.getSdsDocument() != null) {
+            response.setSdsDocumentId(product.getSdsDocument().getId());
+        } else {
+            response.setSdsDocumentId(null);
+        }
+        response.setName(product.getName());
+        response.setCasNumber(product.getCasNumber());
+        response.setEcNumber(product.getEcNumber());
+        response.setSignalWord(product.getSignalWord());
+        response.setPhysicalState(product.getPhysicalState());
+        response.setRestricted(product.getRestricted());
+        response.setCreatedAt(product.getCreatedAt());
+        response.setUpdatedAt(product.getUpdatedAt());
+        return response;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new write/read/delete endpoints backed by JPA persistence and introduces runtime tenant row provisioning via raw SQL, which can affect data integrity and multi-tenant assumptions.
> 
> **Overview**
> Adds a new `/api/chemical-products` CRUD API (create/list/get/update/delete) backed by `ChemicalProductService`, request/response DTOs, and tenant-scoped repository queries.
> 
> Introduces a temporary single-tenant integration stub (`ChemicalIntegrationStubs.STUB_TENANT_ID`) and `StubTenantProvisioner` that idempotently inserts a dev tenant row via `JdbcTemplate` before chemical product writes, while explicitly deferring SDS linking and real tenant resolution to later workstreams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe2e7e54ace9485c76858851f340824da6c4da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->